### PR TITLE
feat(rules): allow void on promises

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -219,7 +219,7 @@
         "no-unsafe-finally": "error",
         "no-unused-labels": "error",
         "no-var": "error",
-        "no-void": "error",
+        "no-void": ["error", { "allowAsStatement": true }],
         "object-shorthand": "error",
         "one-var": [
             "error",


### PR DESCRIPTION
### Description

#### Current behaviour

```typescript
// error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
subscriptionEvent.update({ status: EventStatus.FAILED });

// error  Expected 'undefined' and instead saw 'void'                                                      no-void
void subscriptionEvent.update({ status: EventStatus.FAILED });
```

### Expected behaviour

```typescript
// error  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
subscriptionEvent.update({ status: EventStatus.FAILED });

// no error
void subscriptionEvent.update({ status: EventStatus.FAILED });
```

### Reference

- Rule [`no-void`](https://eslint.org/docs/rules/no-void)
- Rule [`@typescript-eslint/no-floating-promises`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md#ignorevoid)