### PR TITLE
fix(eslintrc): remove prettier/typescript-eslint

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -3,8 +3,7 @@
         "es6": true
     },
     "extends": [
-        "prettier",
-        "prettier/@typescript-eslint"
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -195,7 +194,7 @@
         "no-invalid-this": "error",
         "no-irregular-whitespace": "off",
         "no-magic-numbers": [
-            "error", 
+            "error",
             {
                 "ignoreArrayIndexes": false,
                 "ignore": [0, 1]
@@ -287,7 +286,7 @@
                         true,
                         "always"
                     ],
-                    "typedef": [ 
+                    "typedef": [
                         "error",
                         {
                             "variableDeclarationIgnoreFunction": true,


### PR DESCRIPTION
### Description

An npm error occurres each time we launch eslint with the @algoan/eslint-config v1.1.2:

```
Oops! Something went wrong! :(

ESLint: 7.20.0

ESLint couldn't find the config "prettier/@typescript-eslint" to extend from. Please check that the name of the config is correct.

The config "prettier/@typescript-eslint" was referenced from the config file in "/Users/.../node_modules/@algoan/eslint-config/index.js".

If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
```

- removed "prettier/@typescript-eslint" from the `extends` property