### PR TITLE
[FIX] Fix deprecation error due to rule strict-type-predicates

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -281,7 +281,6 @@
                     "prefer-method-signature": true,
                     "prefer-switch": true,
                     "return-undefined": true,
-                    "strict-type-predicates": true,
                     "switch-final-break": [
                         true,
                         "always"


### PR DESCRIPTION
The presence of the rule `strict-type-predicates` throws the error:

```
The 'strict-type-predicates' rule threw an error in './src/GoogleCloudPubSub/GoogleCloudPubSub.ts':
TypeError: DeprecationError: 'originalKeywordKind' has been deprecated since v5.0.0 and can no longer be used. Use 'identifierToKeywordKind(identifier)' instead.
    at ./node_modules/typescript/lib/typescript.js:171644:13
    at IdentifierObject.<anonymous> (./node_modules/typescript/lib/typescript.js:171674:7)
    at getTypePredicateOneWay (./node_modules/tslint/lib/rules/strictTypePredicatesRule.js:141:23)
    at getTypePredicate (./node_modules/tslint/lib/rules/strictTypePredicatesRule.js:112:14)
    at checkEquals (./node_modules/tslint/lib/rules/strictTypePredicatesRule.js:72:24)
    at cb (./node_modules/tslint/lib/rules/strictTypePredicatesRule.js:65:17)
    at visitNode2 (./node_modules/typescript/lib/typescript.js:27926:20)
    at forEachChildInConditionalExpression (./node_modules/typescript/lib/typescript.js:28548:18)
    at Object.forEachChild (./node_modules/typescript/lib/typescript.js:28019:37)
    at cb (./node_modules/tslint/lib/rules/strictTypePredicatesRule.js:68:19)
```