### PR TITLE
[FEAT] Add dual publish to NPM and GitHub Packages

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -13,7 +13,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ inputs.ref }}
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js
       uses: actions/setup-node@v3
       with:
         node-version: '18.x'
@@ -23,5 +23,8 @@ jobs:
     - run: npm run semantic-release
       name: Run Semantic Release
       env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_GHA_PAT }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT_SEMANTIC_RELEASE }}
+        GITHUB_NPM_CONFIG_REGISTRY: https://npm.pkg.github.com/
+        GITHUB_NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
+        NPM_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,15 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
+    [
+      "@amanda-mitchell/semantic-release-npm-multiple",
+      {
+        "registries": {
+          "github": {},
+          "npm": {}
+        }
+      }
+    ],
     "@semantic-release/github",
     ["@semantic-release/git", {
       "assets": ["package.json", "package-lock.json"],
@@ -11,4 +19,3 @@
   ],
   "preset": "angular"
 }
-  

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-prefer-arrow": "^1.2.3"
       },
       "devDependencies": {
+        "@amanda-mitchell/semantic-release-npm-multiple": "github:algoan/semantic-release-npm-multiple#fd763c631503cb88dd143ce72c5838aa1b19ace4",
         "@commitlint/config-conventional": "^18.0.0",
         "@semantic-release/git": "^10.0.1",
         "commitlint": "^18.0.0",
@@ -39,6 +40,20 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@amanda-mitchell/semantic-release-npm-multiple": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/algoan/semantic-release-npm-multiple.git#fd763c631503cb88dd143ce72c5838aa1b19ace4",
+      "integrity": "sha512-vUXk9RyGXUzhykIzeP5ozPBOsGQtQZH1RRYIyihXmQU6wPd8VgPCpU36TBgqpun7MfUsGH8n5fj28zCmpBwVMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/npm": "^11.0.0",
+        "require-reload": "^0.2.2"
+      },
+      "peerDependencies": {
+        "semantic-release": ">= 19"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -9675,6 +9690,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-reload": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/require-reload/-/require-reload-0.2.2.tgz",
+      "integrity": "sha512-ElZsgUSIyQKuS8Db4t/w30ut7TXWPzEhvBEVWzMHMTHeokHABEiF+oABX/rSp9nEhm+loT/ziZC+/7PQn7+7eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.21"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -11242,6 +11266,16 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
+    },
+    "@amanda-mitchell/semantic-release-npm-multiple": {
+      "version": "git+ssh://git@github.com/algoan/semantic-release-npm-multiple.git#fd763c631503cb88dd143ce72c5838aa1b19ace4",
+      "integrity": "sha512-vUXk9RyGXUzhykIzeP5ozPBOsGQtQZH1RRYIyihXmQU6wPd8VgPCpU36TBgqpun7MfUsGH8n5fj28zCmpBwVMA==",
+      "dev": true,
+      "from": "@amanda-mitchell/semantic-release-npm-multiple@github:algoan/semantic-release-npm-multiple#fd763c631503cb88dd143ce72c5838aa1b19ace4",
+      "requires": {
+        "@semantic-release/npm": "^11.0.0",
+        "require-reload": "^0.2.2"
+      }
     },
     "@babel/code-frame": {
       "version": "7.21.4",
@@ -17997,6 +18031,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "require-reload": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/require-reload/-/require-reload-0.2.2.tgz",
+      "integrity": "sha512-ElZsgUSIyQKuS8Db4t/w30ut7TXWPzEhvBEVWzMHMTHeokHABEiF+oABX/rSp9nEhm+loT/ziZC+/7PQn7+7eA==",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^6.8.0",
     "@typescript-eslint/eslint-plugin-tslint": "^6.8.0",
     "@typescript-eslint/parser": "^6.8.0",
-    "eslint": "^8.52.0",
+    "eslint": ">= 8",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-jsdoc": "^46.8.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript": ">= 3"
   },
   "devDependencies": {
+    "@amanda-mitchell/semantic-release-npm-multiple": "github:algoan/semantic-release-npm-multiple#fd763c631503cb88dd143ce72c5838aa1b19ace4",
     "@commitlint/config-conventional": "^18.0.0",
     "@semantic-release/git": "^10.0.1",
     "commitlint": "^18.0.0",


### PR DESCRIPTION
Use dual publish, as already done on `@algoan/pubsub` (see: https://github.com/algoan/pubsub/pull/435/commits/69006672d7c97d1b29a0a277a114602a48f4a24e).

Also, use this repository to use the last major version of semantic-release, thus use [our fork](https://github.com/algoan/semantic-release-npm-multiple/tree/feature/support-semantic-release-20-and-higher) of [@amanda-mitchell/semantic-release-npm-multiple](https://github.com/amanda-mitchell/semantic-release-npm-multiple) to publish on both registries.

Moreover, `npm install` changed the version of `eslint` from the specific version `^8.52.0` to the same version of `peerDependencies`, since the version on the user side will be defined in their own `package.json` it should have no impact.