### PR TITLE
[FEAT] Allow function in class without use of this

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -131,7 +131,7 @@
             "off"
         ],
         "camelcase": "error",
-        "class-methods-use-this": "error",
+        "class-methods-use-this": ["error", { "enforceForClassFields": false }],
         "comma-dangle": "off",
         "complexity": "error",
         "constructor-super": "error",


### PR DESCRIPTION
See ESLint documentation on [`enforceForClassFields`](https://eslint.org/docs/latest/rules/class-methods-use-this#enforceforclassfields) for more details.